### PR TITLE
Fix etcd listen addressing

### DIFF
--- a/lib/porkadot/configs/etcd.rb
+++ b/lib/porkadot/configs/etcd.rb
@@ -42,14 +42,18 @@ module Porkadot; module Configs
     def listen_address label_key
       listen_address = nil
       if self.raw.labels
-        listen_address = self.raw.labels[label_key] || self.raw.labels[Porkadot::ETCD_LISTEN_ADDRESS_LABEL]
+        listen_address = self.raw.labels[label_key]
+        if !listen_address && label_key == Porkadot::ETCD_LISTEN_PEER_ADDRESS_LABEL
+          listen_address = self.raw.labels[Porkadot::ETCD_LEGACY_LISTEN_PEER_ADDRESS_LABEL]
+        end
+        listen_address ||= self.raw.labels[Porkadot::ETCD_LISTEN_ADDRESS_LABEL]
       end
 
-      if !listen_adress
+      if !listen_address
         if self.ipaddr?(self.raw.hostname)
           listen_address = self.raw.hostname
-        elsif self.ipaddr?(self.raw.name)
-          listen_address = self.raw.name
+        elsif self.ipaddr?(self.name)
+          listen_address = self.name
         else
           listen_address = '0.0.0.0'
         end
@@ -84,7 +88,7 @@ module Porkadot; module Configs
     end
 
     def listen_peer_urls
-      ["https://#{self.listen_client_address}:2380"]
+      ["https://#{self.listen_peer_address}:2380"]
     end
 
     def listen_metrics_urls

--- a/lib/porkadot/const.rb
+++ b/lib/porkadot/const.rb
@@ -7,5 +7,6 @@ module Porkadot
   ETCD_ADDRESS_LABEL = "etcd.unstable.cloud/address"
   ETCD_LISTEN_ADDRESS_LABEL = "etcd.unstable.cloud/listen-address"
   ETCD_LISTEN_CLIENT_ADDRESS_LABEL = "etcd.unstable.cloud/listen-client-address"
-  ETCD_LISTEN_PEER_ADDRESS_LABEL = "etcd.unstable.cloud/listen-client-address"
+  ETCD_LEGACY_LISTEN_PEER_ADDRESS_LABEL = "etcd.unstable.cloud/listen-client-address"
+  ETCD_LISTEN_PEER_ADDRESS_LABEL = "etcd.unstable.cloud/listen-peer-address"
 end

--- a/test/configs/etcd_test.rb
+++ b/test/configs/etcd_test.rb
@@ -26,4 +26,75 @@ class PorkadotConfigsEtcdNodeTest < Minitest::Test
 
     assert_includes node.target_path, 'node01'
   end
+
+  def test_listen_client_address_prefers_client_label
+    node = etcd_node("node01", {
+      labels: {
+        Porkadot::ETCD_LISTEN_ADDRESS_LABEL => "10.0.0.1",
+        Porkadot::ETCD_LISTEN_CLIENT_ADDRESS_LABEL => "10.0.0.2"
+      }
+    })
+
+    assert_equal "10.0.0.2", node.listen_client_address
+  end
+
+  def test_listen_peer_address_prefers_peer_label
+    node = etcd_node("node01", {
+      labels: {
+        Porkadot::ETCD_LEGACY_LISTEN_PEER_ADDRESS_LABEL => "10.0.0.2",
+        Porkadot::ETCD_LISTEN_PEER_ADDRESS_LABEL => "10.0.0.3"
+      }
+    })
+
+    assert_equal "10.0.0.3", node.listen_peer_address
+  end
+
+  def test_listen_peer_address_falls_back_to_legacy_label
+    node = etcd_node("node01", {
+      labels: {
+        Porkadot::ETCD_LEGACY_LISTEN_PEER_ADDRESS_LABEL => "10.0.0.2"
+      }
+    })
+
+    assert_equal "10.0.0.2", node.listen_peer_address
+  end
+
+  def test_listen_address_falls_back_to_shared_listen_label
+    node = etcd_node("node01", {
+      labels: {
+        Porkadot::ETCD_LISTEN_ADDRESS_LABEL => "10.0.0.1"
+      }
+    })
+
+    assert_equal "10.0.0.1", node.listen_client_address
+  end
+
+  def test_listen_address_uses_hostname_when_hostname_is_ip
+    node = etcd_node("node01", {hostname: "10.0.0.1"})
+
+    assert_equal "10.0.0.1", node.listen_client_address
+  end
+
+  def test_listen_address_uses_node_name_when_name_is_ip
+    node = etcd_node("10.0.0.1")
+
+    assert_equal "10.0.0.1", node.listen_client_address
+  end
+
+  def test_listen_address_falls_back_to_any_address
+    node = etcd_node("node01", {hostname: "node01.example.com"})
+
+    assert_equal "0.0.0.0", node.listen_client_address
+  end
+
+  def test_listen_peer_urls_use_peer_address
+    node = etcd_node("node01", {
+      labels: {
+        Porkadot::ETCD_LISTEN_CLIENT_ADDRESS_LABEL => "10.0.0.2",
+        Porkadot::ETCD_LISTEN_PEER_ADDRESS_LABEL => "10.0.0.3"
+      }
+    })
+
+    assert_equal ["https://10.0.0.3:2380"], node.listen_peer_urls
+  end
 end


### PR DESCRIPTION
## Summary

- Fix etcd peer listen address label value
- Keep the old client-address label as a peer fallback for compatibility
- Make peer listen URLs use the peer address instead of the client address
- Add tests for etcd listen address fallback order

## Tests

- bundle exec ruby -Ilib -Itest test/configs/etcd_test.rb
- bundle exec rake test