### PR TITLE
Avoid mutating derived config

### DIFF
--- a/docs/design/refactoring01/CLAUDE.md
+++ b/docs/design/refactoring01/CLAUDE.md
@@ -1,0 +1,36 @@
+# Refactoring01 Implementation Notes
+
+## Required assets regression check
+
+For every implementation based on files in `docs/design/refactoring01`, verify
+that rendering with `../porkadot.yaml` does not unintentionally change generated
+assets.
+
+`assets/` is outside Git tracking, so do not use `git diff -- assets` for this
+check. Instead:
+
+1. Confirm current state.
+   - `git status --short --branch`
+   - `git ls-files assets` should be empty.
+2. Back up the current generated assets into `/tmp`.
+   - `tmp_before=$(mktemp -d /tmp/porkadot-assets-before.XXXXXX)`
+   - `cp -a assets "$tmp_before/assets"`
+3. Render deterministic asset groups with the real config.
+   - `bundle exec exe/porkadot --config ../porkadot.yaml render kubelet`
+   - `bundle exec exe/porkadot --config ../porkadot.yaml render etcd`
+   - `bundle exec exe/porkadot --config ../porkadot.yaml render bootstrap`
+   - `bundle exec exe/porkadot --config ../porkadot.yaml render kubernetes`
+4. Compare generated assets.
+   - `diff -ru "$tmp_before/assets" assets`
+5. Restore the original assets before finishing.
+   - Remove the regenerated `assets/`.
+   - Copy `"$tmp_before/assets"` back to `assets`.
+   - Re-run `diff -ru "$tmp_before/assets" assets` to confirm restoration.
+
+Do not run `render all` or `render certs` for this regression check.
+Certificate/key files may be refreshed or regenerated and can produce unrelated
+diffs.
+
+If the asset diff is not empty, inspect whether the change is intended by the
+current design document. Do not commit regenerated `assets/` unless explicitly
+requested.

--- a/lib/porkadot/configs/kubelet.rb
+++ b/lib/porkadot/configs/kubelet.rb
@@ -71,9 +71,12 @@ module Porkadot; module Configs
     end
 
     def kubelet_config
-      kc = self.raw.config || ::Porkadot::Raw.new
-      kc = kc.merge(self.config.kubernetes.kubelet.config)
-      kc.clusterDNS << self.config.k8s.networking.dns_ip.to_s
+      base = self.config.kubernetes.kubelet.config.to_hash
+      node = self.raw.config ? self.raw.config.to_hash : {}
+      kc = ::Porkadot::Raw.new(base.rmerge(node))
+      kc.clusterDNS = Array(kc.clusterDNS).dup
+      dns_ip = self.config.k8s.networking.dns_ip.to_s
+      kc.clusterDNS << dns_ip unless kc.clusterDNS.include?(dns_ip)
       kc.clusterDomain = self.config.k8s.networking.dns_domain
       if self.raw.taints
         kc.registerWithTaints = self.raw.taints
@@ -110,4 +113,3 @@ module Porkadot; module Configs
     end
   end
 end; end
-

--- a/lib/porkadot/configs/kubernetes.rb
+++ b/lib/porkadot/configs/kubernetes.rb
@@ -210,11 +210,13 @@ module Porkadot; module Configs
       end
 
       def proxy_config kubeconfig=nil
-        self.raw.config['clusterCIDR'] = config.k8s.networking.pod_subnet
+        proxy_config = ::Porkadot::Raw.new(self.raw.config.to_hash)
+        proxy_config['clusterCIDR'] = config.k8s.networking.pod_subnet
         if kubeconfig
-          self.raw.config['clientConnection']['kubeconfig'] = kubeconfig
+          proxy_config['clientConnection'] ||= {}
+          proxy_config['clientConnection']['kubeconfig'] = kubeconfig
         end
-        self.raw.config.to_hash.to_yaml
+        proxy_config.to_hash.to_yaml
       end
 
       def component_name

--- a/test/configs/kubelet_test.rb
+++ b/test/configs/kubelet_test.rb
@@ -68,6 +68,25 @@ class PorkadotConfigsKubeletTest < Minitest::Test
     assert_equal '10.254.0.10', node.kubelet_config['clusterDNS'][0]
   end
 
+  def test_kubelet_config_cluster_dns_is_not_duplicated
+    config = self.mock_config('porkadot2.yaml')
+    node = config.nodes['node04']
+
+    assert_equal ['10.254.0.10'], node.kubelet_config['clusterDNS']
+    assert_equal ['10.254.0.10'], node.kubelet_config['clusterDNS']
+  end
+
+  def test_kubelet_config_does_not_mutate_raw_config
+    config = self.mock_config('porkadot2.yaml')
+    node = config.nodes['node04']
+
+    node.kubelet_config
+
+    assert_equal [], config.kubernetes.kubelet.config['clusterDNS']
+    assert_nil node.raw.config['clusterDNS']
+    assert_nil node.raw.config['clusterDomain']
+  end
+
   def test_kubelet_config_override
     config = self.mock_config('porkadot2.yaml')
     node01 = config.nodes['node01']
@@ -77,5 +96,14 @@ class PorkadotConfigsKubeletTest < Minitest::Test
     assert_equal true, node04.kubelet_config['failSwapOn']
     assert_equal true, node04.kubelet_config['featureGates']['NodeSwap']
     assert_equal false, node04.kubelet_config['featureGates']['CSIMigration']
+  end
+
+  def test_kubelet_config_registers_taints_only_for_tainted_nodes
+    config = self.mock_config('porkadot2.yaml')
+    node01 = config.nodes['node01']
+    node04 = config.nodes['node04']
+
+    assert_equal node01.raw.taints, node01.kubelet_config['registerWithTaints']
+    assert_nil node04.kubelet_config['registerWithTaints']
   end
 end

--- a/test/configs/kubernetes_test.rb
+++ b/test/configs/kubernetes_test.rb
@@ -30,6 +30,25 @@ class PorkadotConfigsK8sTest < Minitest::Test
     assert_includes proxy.proxy_config, "clusterCIDR: #{k8s.networking.pod_subnet}"
   end
 
+  def test_proxy_config_does_not_mutate_raw_config
+    proxy.proxy_config
+
+    assert_nil proxy.raw.config['clusterCIDR']
+  end
+
+  def test_proxy_config_kubeconfig_argument_only_changes_returned_yaml
+    returned = YAML.load(proxy.proxy_config('/tmp/kube-proxy.conf'))
+
+    assert_equal '/tmp/kube-proxy.conf', returned['clientConnection']['kubeconfig']
+    assert_equal '/var/lib/kube-proxy/kubeconfig.conf', proxy.raw.config['clientConnection']['kubeconfig']
+  end
+
+  def test_proxy_config_without_kubeconfig_preserves_default
+    returned = YAML.load(proxy.proxy_config)
+
+    assert_equal '/var/lib/kube-proxy/kubeconfig.conf', returned['clientConnection']['kubeconfig']
+  end
+
   def test_apiserver_default_args
     assert_includes apiserver.default_args, '--v'
     assert_includes apiserver.default_args, '--advertise-address'


### PR DESCRIPTION
## Summary
- Build kubelet and kube-proxy derived configs from copies instead of mutating raw config
- Add regression tests for repeated config derivation and raw state cleanliness
- Document the required untracked assets regression check for refactoring01 work

## Tests
- bundle exec ruby -Ilib -Itest test/configs/kubelet_test.rb
- bundle exec ruby -Ilib -Itest test/configs/kubernetes_test.rb
- bundle exec rake test
- Rendered ../porkadot.yaml assets and compared against a backup; only certificate files changed, manifest/config assets were unchanged and assets were restored