### PR TITLE
Add config validator

### DIFF
--- a/lib/porkadot.rb
+++ b/lib/porkadot.rb
@@ -11,6 +11,7 @@ end
 
 require 'porkadot/const'
 require 'porkadot/utils/hash_recursive_merge'
+require 'porkadot/config_validator'
 require 'porkadot/config'
 require 'porkadot/assets'
 require 'porkadot/utils'

--- a/lib/porkadot/assets/kubernetes.rb
+++ b/lib/porkadot/assets/kubernetes.rb
@@ -105,6 +105,10 @@ module Porkadot; module Assets
       @@crds[name] = crds
     end
 
+    def self.manifest_names
+      @@manifests.keys
+    end
+
     register_manifests('flannel', [
       'flannel/flannel.yaml',
       'flannel/kustomization.yaml'

--- a/lib/porkadot/config.rb
+++ b/lib/porkadot/config.rb
@@ -89,6 +89,10 @@ module Porkadot
       File.join(self.assets_dir, 'secrets')
     end
 
+    def validate!
+      Porkadot::ConfigValidator.new(self).validate!
+    end
+
   end
 
   module ConfigUtils

--- a/lib/porkadot/config_validator.rb
+++ b/lib/porkadot/config_validator.rb
@@ -1,0 +1,147 @@
+require 'ipaddr'
+
+module Porkadot
+  class ConfigValidator
+    Error = Class.new(StandardError)
+
+    def initialize(config)
+      @config = config
+    end
+
+    def validate!
+      errors = validate
+      raise Error, errors.join("\n") unless errors.empty?
+      true
+    end
+
+    def validate
+      errors = []
+
+      validate_nodes(errors)
+      validate_control_plane_endpoint(errors)
+      validate_cidrs(errors)
+      validate_addons(errors)
+      validate_connection(errors)
+
+      errors
+    end
+
+    private
+
+    attr_reader :config
+
+    def raw
+      config.raw
+    end
+
+    def validate_nodes(errors)
+      nodes = raw.nodes
+      unless nodes.is_a?(Hash)
+        errors << 'nodes must be a Hash'
+        return
+      end
+
+      nodes.each do |name, node|
+        next unless node.is_a?(Hash)
+
+        labels = node[:labels] || node['labels']
+        next unless labels.is_a?(Hash)
+        next unless labels.key?(Porkadot::ETCD_MEMBER_LABEL)
+
+        value = labels[Porkadot::ETCD_MEMBER_LABEL]
+        if blank?(value)
+          errors << "nodes.#{name}.labels.#{Porkadot::ETCD_MEMBER_LABEL} must not be empty"
+        end
+      end
+    end
+
+    def validate_control_plane_endpoint(errors)
+      endpoint = raw.dig(:kubernetes, :control_plane_endpoint)
+      if blank?(endpoint)
+        errors << 'kubernetes.control_plane_endpoint is required'
+        return
+      end
+
+      unless endpoint.is_a?(String)
+        errors << 'kubernetes.control_plane_endpoint must be a String'
+        return
+      end
+
+      host, port = split_host_port(endpoint)
+      if blank?(host) || blank?(port)
+        errors << 'kubernetes.control_plane_endpoint must include host and port'
+      end
+    end
+
+    def validate_cidrs(errors)
+      validate_cidr_list(errors, 'kubernetes.networking.service_subnet',
+        raw.dig(:kubernetes, :networking, :service_subnet))
+      validate_cidr_list(errors, 'kubernetes.networking.pod_subnet',
+        raw.dig(:kubernetes, :networking, :pod_subnet))
+    end
+
+    def validate_cidr_list(errors, path, value)
+      if blank?(value)
+        errors << "#{path} is required"
+        return
+      end
+
+      unless value.is_a?(String)
+        errors << "#{path} must be a String"
+        return
+      end
+
+      value.split(',').each do |cidr|
+        cidr = cidr.strip
+        begin
+          IPAddr.new(cidr)
+        rescue IPAddr::InvalidAddressError
+          errors << "#{path} contains invalid CIDR: #{cidr}"
+        end
+      end
+    end
+
+    def validate_addons(errors)
+      enabled = raw.dig(:addons, :enabled)
+      unless enabled.is_a?(Array)
+        errors << 'addons.enabled must be an Array'
+        return
+      end
+
+      known_addons = Porkadot::Assets::Addons.manifest_names
+      enabled.each do |name|
+        next if known_addons.include?(name)
+
+        errors << "addons.enabled contains unknown addon: #{name}"
+      end
+    end
+
+    def validate_connection(errors)
+      user = raw.dig(:connection, :user)
+      errors << 'connection.user is required' if blank?(user)
+
+      port = raw.dig(:connection, :port)
+      unless integerish?(port)
+        errors << 'connection.port must be an Integer'
+      end
+    end
+
+    def split_host_port(endpoint)
+      index = endpoint.rindex(':')
+      return [nil, nil] unless index
+
+      [endpoint[0, index], endpoint[(index + 1)..-1]]
+    end
+
+    def integerish?(value)
+      return true if value.is_a?(Integer)
+      return false unless value.is_a?(String)
+
+      value.match?(/\A\d+\z/)
+    end
+
+    def blank?(value)
+      value.nil? || (value.respond_to?(:empty?) && value.empty?)
+    end
+  end
+end

--- a/lib/porkadot/utils.rb
+++ b/lib/porkadot/utils.rb
@@ -13,7 +13,8 @@ module Porkadot::Utils
     unless defined?(@config)
       opts = options.dup
       opts = opts.merge(parent_options) if parent_options
-      @config = Porkadot::Config.new(options[:config])
+      @config = Porkadot::Config.new(opts[:config])
+      @config.validate!
     end
     @config
   end
@@ -22,4 +23,3 @@ module Porkadot::Utils
     self.config.logger
   end
 end
-

--- a/lib/porkadot/utils/hash_recursive_merge.rb
+++ b/lib/porkadot/utils/hash_recursive_merge.rb
@@ -34,7 +34,7 @@ module Porkadot::HashRecursiveMerge
   # 
   def rmerge!(other_hash)
     merge!(other_hash) do |key, oldval, newval|
-      oldval.class == self.class ? oldval.rmerge!(newval) : newval
+      oldval.class == self.class && newval.class == self.class ? oldval.rmerge!(newval) : newval
     end
   end
 
@@ -61,7 +61,7 @@ module Porkadot::HashRecursiveMerge
   # 
   def rmerge(other_hash)
     merge(other_hash) do |key, oldval, newval|
-      oldval.class == self.class ? oldval.rmerge(newval) : newval
+      oldval.class == self.class && newval.class == self.class ? oldval.rmerge(newval) : newval
     end
   end
 

--- a/test/config_validator_test.rb
+++ b/test/config_validator_test.rb
@@ -1,0 +1,123 @@
+require 'tempfile'
+require 'test_helper'
+
+class PorkadotConfigValidatorTest < Minitest::Test
+  include Porkadot::TestUtils
+
+  def test_valid_fixture_returns_true
+    assert_equal true, mock_config.validate!
+  end
+
+  def test_missing_control_plane_endpoint_raises_error
+    config = config_with do |data|
+      data['kubernetes'].delete('control_plane_endpoint')
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+    assert_includes error.message, 'kubernetes.control_plane_endpoint is required'
+  end
+
+  def test_nodes_must_be_hash
+    config = config_with do |data|
+      data['nodes'] = ['node01']
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+    assert_includes error.message, 'nodes must be a Hash'
+  end
+
+  def test_invalid_cidr_raises_error
+    config = config_with do |data|
+      data['kubernetes']['networking']['pod_subnet'] = 'invalid-cidr'
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+    assert_includes error.message,
+      'kubernetes.networking.pod_subnet contains invalid CIDR: invalid-cidr'
+  end
+
+  def test_unknown_addon_raises_error
+    config = config_with do |data|
+      data['addons'] ||= {}
+      data['addons']['enabled'] = ['flannel', 'unknown-addon']
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+    assert_includes error.message,
+      'addons.enabled contains unknown addon: unknown-addon'
+  end
+
+  def test_empty_etcd_member_label_raises_error
+    config = config_with do |data|
+      data['nodes']['node01']['labels'][Porkadot::ETCD_MEMBER_LABEL] = nil
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+    assert_includes error.message,
+      'nodes.node01.labels.etcd.unstable.cloud/member must not be empty'
+  end
+
+  def test_invalid_connection_port_raises_error
+    config = config_with do |data|
+      data['connection']['port'] = 'ssh'
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+    assert_includes error.message, 'connection.port must be an Integer'
+  end
+
+  def test_blank_connection_user_raises_error
+    config = config_with do |data|
+      data['connection']['user'] = ''
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+    assert_includes error.message, 'connection.user is required'
+  end
+
+  def test_multiple_errors_are_aggregated
+    config = config_with do |data|
+      data['nodes'] = ['node01']
+      data['connection']['user'] = ''
+      data['connection']['port'] = 'ssh'
+    end
+
+    error = assert_raises(Porkadot::ConfigValidator::Error) do
+      config.validate!
+    end
+
+    assert_includes error.message, 'nodes must be a Hash'
+    assert_includes error.message, 'connection.user is required'
+    assert_includes error.message, 'connection.port must be an Integer'
+    assert_operator error.message.lines.size, :>=, 3
+  end
+
+  private
+
+  def config_with
+    data = YAML.load_file(File.join(TEST_FIXTURES_DIR, 'config', 'porkadot.yaml'))
+    yield data
+
+    file = Tempfile.new(['porkadot', '.yaml'])
+    file.write(data.to_yaml)
+    file.close
+
+    Porkadot::Config.new(file.path)
+  ensure
+    file&.unlink
+  end
+end

--- a/test/fixtures/config/porkadot.yaml
+++ b/test/fixtures/config/porkadot.yaml
@@ -8,7 +8,7 @@ nodes:
     hostname: 192.168.33.111
     labels:
       "k8s.unstable.cloud/master":
-      "etcd.unstable.cloud/member":
+      "etcd.unstable.cloud/member": node01
     taints:
       "node-role.kubernetes.io/master": :NoSchedule"
   '192.168.33.112':


### PR DESCRIPTION
## Summary
- add ConfigValidator to fail early on invalid Porkadot config
- validate CLI config loading before render/install/setup commands use it
- expose addon manifest names for unknown addon validation

## Verification
- bundle exec rake test
- rendered HEAD~1 and HEAD with ../porkadot.yaml and compared assets; non-secret outputs matched