### PR TITLE
Add explicit config accessors

### DIFF
--- a/lib/porkadot/config.rb
+++ b/lib/porkadot/config.rb
@@ -118,6 +118,8 @@ module Porkadot
       File.join(self.target_secrets_path, file.to_s)
     end
 
+    # Compatibility fallback for legacy implicit config access.
+    # Prefer explicit accessors on config classes for public settings.
     def method_missing name, *args
       return nil if self.raw.nil?
       self.raw[name]

--- a/lib/porkadot/configs/etcd.rb
+++ b/lib/porkadot/configs/etcd.rb
@@ -8,6 +8,18 @@ module Porkadot; module Configs
       @raw = config.raw.etcd
     end
 
+    def image_repository
+      self.raw.image_repository
+    end
+
+    def image_tag
+      self.raw.image_tag
+    end
+
+    def extra_env
+      self.raw.extra_env
+    end
+
     def advertise_client_urls
       urls = []
       config.etcd_nodes.each do |_, v|

--- a/lib/porkadot/configs/kubelet.rb
+++ b/lib/porkadot/configs/kubelet.rb
@@ -70,6 +70,10 @@ module Porkadot; module Configs
       return self.raw.annotations || {}
     end
 
+    def taints
+      return self.raw.taints
+    end
+
     def kubelet_config
       base = self.config.kubernetes.kubelet.config.to_hash
       node = self.raw.config ? self.raw.config.to_hash : {}

--- a/lib/porkadot/configs/kubernetes.rb
+++ b/lib/porkadot/configs/kubernetes.rb
@@ -22,6 +22,26 @@ module Porkadot; module Configs
       self.raw.cluster_name || 'porkadot'
     end
 
+    def control_plane_endpoint
+      self.raw.control_plane_endpoint
+    end
+
+    def kubernetes_version
+      self.raw.kubernetes_version
+    end
+
+    def crictl_version
+      self.raw.crictl_version
+    end
+
+    def image_repository
+      self.raw.image_repository
+    end
+
+    def log_level
+      self.raw.log_level
+    end
+
     def target_path
       File.join(self.config.assets_dir, 'kubernetes')
     end
@@ -94,6 +114,18 @@ module Porkadot; module Configs
         'kube-apiserver'
       end
 
+      def bind_port
+        self.raw.bind_port
+      end
+
+      def extra_args
+        self.raw.extra_args
+      end
+
+      def log_level
+        config.kubernetes.log_level || raw.log_level || 2
+      end
+
       def bootstrap_args
         return {}
       end
@@ -148,6 +180,14 @@ module Porkadot; module Configs
         'kube-scheduler'
       end
 
+      def extra_args
+        self.raw.extra_args
+      end
+
+      def log_level
+        config.kubernetes.log_level || raw.log_level || 2
+      end
+
       def bootstrap_args
         return %W(
           --kubeconfig=/etc/kubernetes/bootstrap/kubeconfig-bootstrap.yaml
@@ -175,6 +215,14 @@ module Porkadot; module Configs
 
       def component_name
         'kube-controller-manager'
+      end
+
+      def extra_args
+        self.raw.extra_args
+      end
+
+      def log_level
+        config.kubernetes.log_level || raw.log_level || 2
       end
 
       def bootstrap_args
@@ -243,6 +291,26 @@ module Porkadot; module Configs
       def initialize config
         @config = config
         @raw = config.raw.kubernetes.networking
+      end
+
+      def service_subnet
+        self.raw.service_subnet
+      end
+
+      def pod_subnet
+        self.raw.pod_subnet
+      end
+
+      def dns_domain
+        self.raw.dns_domain
+      end
+
+      def additional_domains
+        self.raw.additional_domains
+      end
+
+      def cni_version
+        self.raw.cni_version
       end
 
       def kubernetes_ip

--- a/test/configs/etcd_test.rb
+++ b/test/configs/etcd_test.rb
@@ -11,6 +11,12 @@ class PorkadotConfigsEtcdTest < Minitest::Test
   def test_advertise_urls
     assert_equal ["https://192.168.33.111:2379", "https://192.168.33.112:2379"], etcd.advertise_client_urls
   end
+
+  def test_explicit_accessors
+    assert_equal "registry.k8s.io/etcd", etcd.image_repository
+    assert_equal "3.5.12-0", etcd.image_tag
+    assert_equal [], etcd.extra_env
+  end
 end
 
 class PorkadotConfigsEtcdNodeTest < Minitest::Test

--- a/test/configs/kubelet_test.rb
+++ b/test/configs/kubelet_test.rb
@@ -55,6 +55,20 @@ class PorkadotConfigsKubeletTest < Minitest::Test
     assert_equal 'k8s.unstable.cloud/master,etcd.unstable.cloud/member=node01', node.labels_string
   end
 
+  def test_explicit_accessors
+    config = self.mock_config('porkadot2.yaml')
+    node = config.nodes['node01']
+
+    assert_equal({
+      'k8s.unstable.cloud/master' => nil,
+      'etcd.unstable.cloud/member' => 'node01'
+    }, node.labels.to_hash)
+    assert_equal({}, node.annotations)
+    assert_equal({ 'node-role.kubernetes.io/master' => ':NoSchedule' }, node.taints.to_hash)
+    assert_equal '192.168.33.111', node.hostname
+    assert_equal '192.168.33.115', config.nodes['192.168.33.115'].hostname
+  end
+
   def test_node04_labels_string_should_be_blank
     config = self.mock_config('porkadot2.yaml')
     node = config.nodes['node04']

--- a/test/configs/kubernetes_test.rb
+++ b/test/configs/kubernetes_test.rb
@@ -26,6 +26,39 @@ class PorkadotConfigsK8sTest < Minitest::Test
     assert_equal ['192.168.33.101', '6443'], k8s.control_plane_endpoint_host_and_port
   end
 
+  def test_explicit_accessors
+    assert_equal 'porkadot', k8s.cluster_name
+    assert_equal '192.168.33.101:6443', k8s.control_plane_endpoint
+    assert_equal 'v1.17.2', k8s.kubernetes_version
+    assert_equal 'v1.28.0', k8s.crictl_version
+    assert_equal 'registry.k8s.io', k8s.image_repository
+    assert_nil k8s.log_level
+  end
+
+  def test_networking_explicit_accessors
+    assert_equal '10.254.0.0/24', networking.service_subnet
+    assert_equal '10.244.0.0/16', networking.pod_subnet
+    assert_equal 'cluster.local', networking.dns_domain
+    assert_equal [], networking.additional_domains
+    assert_equal 'v0.9.1', networking.cni_version
+  end
+
+  def test_apiserver_explicit_accessors
+    assert_equal 6443, apiserver.bind_port
+    assert_equal ['--bind-address=127.0.0.1'], apiserver.extra_args
+    assert_equal 2, apiserver.log_level
+  end
+
+  def test_scheduler_explicit_accessors
+    assert_nil k8s.scheduler.extra_args
+    assert_equal 2, k8s.scheduler.log_level
+  end
+
+  def test_controller_manager_explicit_accessors
+    assert_nil k8s.controller_manager.extra_args
+    assert_equal 2, k8s.controller_manager.log_level
+  end
+
   def test_proxy_config_has_cluster_cidr
     assert_includes proxy.proxy_config, "clusterCIDR: #{k8s.networking.pod_subnet}"
   end


### PR DESCRIPTION
## Summary
- add explicit accessors for high-use Kubernetes, etcd, and kubelet config fields
- document ConfigUtils#method_missing as a legacy compatibility fallback
- cover the new accessors in config tests

## Tests
- bundle exec ruby -Ilib -Itest test/configs/kubernetes_test.rb test/configs/etcd_test.rb test/configs/kubelet_test.rb
- bundle exec rake test

## Asset regression
- rendered kubelet, etcd, bootstrap, and kubernetes assets with ../porkadot.yaml
- observed only certificate re-signing diffs during render check
- restored assets to the pre-render snapshot